### PR TITLE
Handle null lat/lng values when setting map center

### DIFF
--- a/geo_map/static/geo_map/helpers.js
+++ b/geo_map/static/geo_map/helpers.js
@@ -172,9 +172,28 @@ function debounce(func, wait) {
   };
 }
 
-function calculateCenterBetweenTwoSites(site1, site2) {
-  const centerLat = (site1.lat + site2.lat) / 2;
-  const centerLng = (site1.lng + site2.lng) / 2;
+function calculateCenterBetweenTwoSites(sites) {
+  const validSites = [];
+  for (const site of sites) {
+    if (site.lat !== null && site.lng !== null) {
+      validSites.push(site);
+    }
+
+    if (validSites.length === 2) {
+      break;
+    }
+  }
+
+  if (validSites.length === 0) {
+    return null;
+  }
+
+  if (validSites.length === 1) {
+    return { lat: validSites[0].lat, lng: validSites[0].lng };
+  }
+
+  const centerLat = (validSites[0].lat + validSites[1].lat) / 2;
+  const centerLng = (validSites[0].lng + validSites[1].lng) / 2;
 
   return { lat: centerLat, lng: centerLng };
 }

--- a/geo_map/static/geo_map/index.js
+++ b/geo_map/static/geo_map/index.js
@@ -207,16 +207,6 @@ async function initMap() {
     selectedTenants,
     selectedFiberLinkStatuses
   );
-
-  if (initialLoad) {
-    initialLoad = false;
-    fetchAndDrawPolylinesOnMap(
-      selectedTenants,
-      selectedFiberLinkStatuses,
-      selectedPopsStatuses,
-      selectedGroups
-    );
-  }
 }
 
 function combineData(linksArray, sitesArray) {
@@ -328,15 +318,19 @@ function fetchSitesByRegion(
       }));
 
       if (siteCoordinates.length >= 2) {
-        const centerCoordinates = calculateCenterBetweenTwoSites(
-          siteCoordinates[0],
-          siteCoordinates[1]
-        );
+        const centerCoordinates =
+          calculateCenterBetweenTwoSites(siteCoordinates);
         map.setCenter(centerCoordinates);
         map.setZoom(11);
       } else if (siteCoordinates.length === 1) {
-        map.setCenter(siteCoordinates[0]);
-        map.setZoom(13);
+        const { lat, lng } = siteCoordinates[0];
+        if (lat !== null && lng !== null) {
+          map.setCenter(siteCoordinates[0]);
+          map.setZoom(13);
+        } else {
+          map.setCenter(storedMapCenter);
+          map.setZoom(storedZoomLevel);
+        }
       }
 
       clearDisplayedMarkers();
@@ -479,6 +473,15 @@ function fetchDataAndCreateMap(
           combinedData,
           selectedFiberLinkStatuses,
           selectedTenants
+        );
+      }
+      if (initialLoad) {
+        initialLoad = false;
+        fetchAndDrawPolylinesOnMap(
+          selectedTenants,
+          ["active"],
+          ["active"],
+          ["access", "core", "distribution", "pit"]
         );
       }
       addMarkersForFilteredSites(data, selectedPopsStatuses, selectedGroups);

--- a/geo_map/static/geo_map/index.js
+++ b/geo_map/static/geo_map/index.js
@@ -317,22 +317,15 @@ function fetchSitesByRegion(
         lng: site.longitude,
       }));
 
-      if (siteCoordinates.length >= 2) {
-        const centerCoordinates =
-          calculateCenterBetweenTwoSites(siteCoordinates);
-        map.setCenter(centerCoordinates);
+      const coordinates = calculateCenterBetweenTwoSites(siteCoordinates);
+      if(coordinates) {
+        map.setCenter(coordinates);
         map.setZoom(11);
-      } else if (siteCoordinates.length === 1) {
-        const { lat, lng } = siteCoordinates[0];
-        if (lat !== null && lng !== null) {
-          map.setCenter(siteCoordinates[0]);
-          map.setZoom(13);
-        } else {
-          map.setCenter(storedMapCenter);
-          map.setZoom(storedZoomLevel);
-        }
+      } else {
+        map.setCenter(storedMapCenter);
+        map.setZoom(storedZoomLevel);
       }
-
+      
       clearDisplayedMarkers();
 
       allLinks.forEach((link) => {


### PR DESCRIPTION
 - add validation to ensure `lat` and `lng` are not null before setting the map center for a single site
 - move fetch and draw polylines logic to run during the initial load of the map 
